### PR TITLE
Fix broken links

### DIFF
--- a/docs/introduction/security.md
+++ b/docs/introduction/security.md
@@ -1,3 +1,3 @@
 # Security
 
-All Lido Liquid Staking for Terra smart contracts have been audited by https://www.oaksecurity.io. Check you the [security report](https://github.com/oak-security/audit-reports/blob/master/Lido%20Finance/2021-11-23%20Audit%20Report%20-%20Lido%20Finance%20stLuna%20v1.2.pdf.).
+All Lido Liquid Staking for Terra smart contracts have been audited by [oaksecurity](https://www.oaksecurity.io). Check you the [security report](https://github.com/oak-security/audit-reports/blob/master/Lido%20Finance/2021-11-23%20Audit%20Report%20-%20Lido%20Finance%20stLuna%20v1.2.pdf).


### PR DESCRIPTION
oaksecurity.io was being parsed with a . at the end, and same with the security report.